### PR TITLE
small fixes and organism embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ model = AlphaGenome()
 
 dna = torch.randint(0, 5, (2, 8192))
 
-pred_nucleotide, single, pairwise = model(dna) # (2, 8192, 5), (2, 64, 1536), (2, 4, 4, 1536)
+pred_nucleotide, single, pairwise = model(dna) # (2, 8192, 5), (2, 64, 1536), (2, 4, 4, 128)
+print(pred_nucleotide.shape, single.shape, pairwise.shape)
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ from alphagenome_pytorch import AlphaGenome
 model = AlphaGenome()
 
 dna = torch.randint(0, 5, (2, 8192))
+organism_index = torch.tensor([0, 0], dtype=torch.long) # the organism that each sequence belongs to
 
-pred_nucleotide, single, pairwise = model(dna) # (2, 8192, 5), (2, 64, 1536), (2, 4, 4, 128)
+pred_nucleotide, single, pairwise = model(dna, organism_index) # (2, 8192, 5), (2, 64, 1536), (2, 4, 4, 128)
 print(pred_nucleotide.shape, single.shape, pairwise.shape)
 ```
 

--- a/alphagenome_pytorch/alphagenome.py
+++ b/alphagenome_pytorch/alphagenome.py
@@ -706,15 +706,15 @@ class AlphaGenome(Module):
 
         # attention
 
-        single, pairwise = self.transformer(x)
+        single, pairwise = self.transformer(x) # 1D 128bp resolution, 2D contact pairs
 
         # ups with skips from down
 
-        x = rearrange(x, 'b n d -> b d n')
+        x = rearrange(single, 'b n d -> b d n')
 
         for up in self.ups:
             x = up(x, skip = skips.pop())
 
-        pred = rearrange(x, 'b l n -> b n l') # 1bp resolution
+        pred = rearrange(x, 'b l n -> b n l') # 1D 1bp resolution
 
         return pred, single, pairwise

--- a/tests/test_alphagenome.py
+++ b/tests/test_alphagenome.py
@@ -28,8 +28,9 @@ def test_alphagenome():
     model = AlphaGenome()
 
     dna = torch.randint(0, 5, (2, 8192))
+    organism_index = torch.tensor([0, 0], dtype=torch.long)
 
-    pred_nucleotide_logits, single, pairwise = model(dna)
+    pred_nucleotide_logits, single, pairwise = model(dna, organism_index)
 
     pred = pred_nucleotide_logits.argmax(dim = -1)
 


### PR DESCRIPTION
- small fixes:
    - README
    - passing transformer tower output through UpresBlock

- added organism embeddings:
    - before transformer block
    - after Upresblock
    - *doubt*: currently, one can indicate from which organism each sequence in the batch comes from. While flexible, it may not be practical considering output heads and can be fixed for the same organism for the whole batch.

Now, forward pass returns expected shapes from Extended Data Fig. 1.

Still missing processing these embeddings with output heads classes.